### PR TITLE
Implement CloudflareError to the http response as a final possibility

### DIFF
--- a/gd/errors.py
+++ b/gd/errors.py
@@ -106,6 +106,15 @@ class LoginFailed(ClientError):
         self._name = name
         self._hashed_password = hashed_password
 
+@frozen()
+class CloudFlareError(ClientError):
+    error_code:int
+    
+    @classmethod
+    def from_str(cls, error:str):
+        return cls(int(error.split(":")[1])
+
+
 
 PERMANENT = "permanently banned from posting comments; reason: `{}`"
 permanent = PERMANENT.format

--- a/gd/http.py
+++ b/gd/http.py
@@ -120,6 +120,7 @@ from gd.errors import (
     MissingAccess,
     NothingFound,
     SongRestricted,
+    CloudflareError
 )
 from gd.filters import Filters
 from gd.models import CommentBannedModel
@@ -887,6 +888,14 @@ class HTTPClient:
                                     raise error_codes.get(
                                         error_code, unexpected_error_code(error_code)
                                     )
+
+                        # There is a small probability we may also encounter a cloudflare error
+                        # This commonly can occur over proxies but on rare occasions this can also 
+                        # be encountered normally
+                        if type is ResponseType.BYTES and response_data.startswith(b"error code:"):
+                            raise CloudFlareError.from_str(response_data.decode("utf-8", "surrogateescape"))
+                        elif type is ResponseType.TEXT and response_data.startswith("error code:")
+                            raise CloudFlareError.from_str(response_data)
 
                         return response_data
 


### PR DESCRIPTION
This seems to happen over proxies but sometimes randomly and since I made an extension this one time that adds proxy support and sometimes I would get the string like `error code: XXX` even if the response went through as a `200 OK`. I thought it would be a smart idea to add this in as an extra safety mechanism incase needed. I have plans to implement another check such as seeing if html pops up (aka. cloudflare IUAM I'm under attack mode) instead of robtop's normal server responses but it may require another parameter in the future incase of false positives so for now this is the best I could do.


